### PR TITLE
Open the browser to the landing page with npm start

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test:fmt": "prettier --list-different \"src/**/*.{tsx,ts}\" || echo \"Run npm run fmt to fix formatting on these files\"",
     "test:lint": "tslint --project tsconfig.json \"src/**/*.{ts,tsx}\"",
     "build": "webpack --config webpack.production.js",
-    "start": "webpack-dev-server",
+    "start": "webpack-dev-server --open",
     "prepare": "tsc -p tsconfig.package.json"
   },
   "repository": {


### PR DESCRIPTION
Minor dev loop optimization. Passing the option flag to webpack-dev-server so that the page opens in the web browser after running npm start.