### PR TITLE
feat: show the chunk names instead of the id when available

### DIFF
--- a/src/client/components/graphs/chunk-graph.component.tsx
+++ b/src/client/components/graphs/chunk-graph.component.tsx
@@ -49,12 +49,15 @@ export const ChunkGraph = withRouter(
         const area = Math.max(minBubbleArea, maxBubbleArea * weight);
         const previous = this.props.previous.chunks!.find(c => c.id === chunk.id);
 
+        // If the chunk has a friendly name, render that in the chart. Otherwise, list the chunk id.
+        const chunkLabel = chunk.names.length > 0 ? chunk.names[0] : `Chunk ${chunk.id}`
+
         return {
           data: fileSizeNode({
             id: String(chunk.id),
             chunkId: chunk.id,
             shortLabel: '' + chunk.id,
-            label: `Chunk ${chunk.id}`,
+            label: chunkLabel,
             fromSize: previous ? previous.size : 0,
             toSize: chunk.size,
             area,


### PR DESCRIPTION
We have ~40 chunks in our dependency graph in Office Online. To make bundle analysis a bit easier, we added some names to chunks that are critical boot performance. With this change, the chunk graph now shows loginRoute instead of Chunk 0, making it easier to reason about.