### PR TITLE
fix: Decode the query argument before splitting

### DIFF
--- a/src/client/redux/epics.ts
+++ b/src/client/redux/epics.ts
@@ -24,8 +24,7 @@ const seedFromQueryStringEpic: Epic = () => {
 
   return of(
     loadAllUrls({
-      resources: query
-        .slice(index + prefix.length)
+      resources: decodeURIComponent(query.slice(index + prefix.length))
         .split(',')
         .map(url => ({ url: Base64.decode(url) })),
     }),


### PR DESCRIPTION
AzureDevOps by default encodes the query part of the url. This means the `,` that is between the hashes is encoded as `%2C`. 
Because of this the split doesn't work and we don't have two valid urls.

This PR makes sure we first decode the value before splitting.