### PR TITLE
Add tooltip for module name

### DIFF
--- a/src/client/components/module-table.component.tsx
+++ b/src/client/components/module-table.component.tsx
@@ -9,14 +9,14 @@ import {
   compareAllModules,
   getNodeModuleFromIdentifier,
   IWebpackModuleComparisonOutput,
-  replaceLoaderInIdentifier
+  replaceLoaderInIdentifier,
 } from '../stat-reducers';
 import styles from './module-table.component.scss';
 import {
   formatDifference,
   formatPercentageDifference,
   linkToModule,
-  linkToNodeModule
+  linkToNodeModule,
 } from './util';
 
 interface IProps {


### PR DESCRIPTION
When module name is long it is getting wrapped on the next line and, due to fixed size of the cell, it gets truncated without any way to see the full name.

This PR adds a title attribute for name cell to serve as a tooltip on hover.

Example:
![image](https://user-images.githubusercontent.com/70098623/138453727-82312be7-4bb9-43ad-97f9-01f7fbbd6d8d.png)
